### PR TITLE
Add Randomize button to particle controls. Fixes #1

### DIFF
--- a/src/components/ParticleApp.jsx
+++ b/src/components/ParticleApp.jsx
@@ -16,6 +16,7 @@ import {
   ExternalLink,
   Code,
   Github,
+  Dices,
   Star,
 } from "lucide-react";
 
@@ -68,6 +69,47 @@ const ParticleApp = () => {
   const handleParticlesInit = useCallback((info) => {
     setParticleInfo(info);
   }, []);
+
+  // Define control ranges for randomization
+  const controlRanges = {
+    particleGap: { min: 2, max: 10, step: 1 },
+    mouseForce: { min: 10, max: 100, step: 1 },
+    gravity: { min: 0.01, max: 0.2, step: 0.01 },
+    noise: { min: 0, max: 50, step: 1 },
+    clickStrength: { min: 0, max: 200, step: 1 },
+    hueRotation: { min: 0, max: 360, step: 1 }
+  };
+
+  const handleRandomize = useCallback(() => {
+    const randomConfig = { ...config };
+    
+    // Randomize numeric controls
+    Object.keys(controlRanges).forEach(key => {
+      const { min, max, step } = controlRanges[key];
+      const range = max - min;
+      const steps = Math.floor(range / step);
+      const randomStep = Math.floor(Math.random() * (steps + 1));
+      randomConfig[key] = min + (randomStep * step);
+      
+      // Round to avoid floating point precision issues
+      if (step < 1) {
+        randomConfig[key] = Math.round(randomConfig[key] * 100) / 100;
+      }
+    });
+    
+    // Randomize particle shape
+    const shapes = ['square', 'circle', 'triangle'];
+    randomConfig.particleShape = shapes[Math.floor(Math.random() * shapes.length)];
+    
+    // Randomize filter
+    const filters = ['none', 'grayscale', 'sepia', 'invert'];
+    randomConfig.filter = filters[Math.floor(Math.random() * filters.length)];
+    
+    // Randomly enable/disable vortex mode (30% chance)
+    randomConfig.vortexMode = Math.random() < 0.3;
+    
+    setConfig(randomConfig);
+  }, [config, controlRanges]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-primary/5">
@@ -245,6 +287,7 @@ const ParticleApp = () => {
                 onExplode={handleExplode}
                 onImageLoad={handleImageLoad}
                 onClose={() => setControlsOpen(false)}
+                onRandomize={handleRandomize}
               />
             </div>
 
@@ -275,6 +318,7 @@ const ParticleApp = () => {
                         onExplode={handleExplode}
                         onImageLoad={handleImageLoad}
                         onClose={() => setControlsOpen(false)}
+                        onRandomize={handleRandomize}
                       />
                     </div>
                   </motion.div>

--- a/src/components/ParticleControl.jsx
+++ b/src/components/ParticleControl.jsx
@@ -9,10 +9,10 @@ import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { motion } from "framer-motion"
-import { RotateCcw, Zap, Upload, Settings, Palette, MousePointer, Code, X } from "lucide-react"
+import { RotateCcw, Zap, Upload, Settings, Palette, MousePointer, Code, X, Dices } from "lucide-react"
 import CodeSnippet from "./CodeSnippet"
 
-const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onImageLoad, onClose }) => {
+const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onImageLoad, onClose, onRandomize }) => {
   const handleSliderChange = (key, value) => {
     onConfigChange({ ...config, [key]: value[0] })
   }
@@ -86,15 +86,20 @@ const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onImageL
       </CardHeader>
       <CardContent className="space-y-6">
         {/* Quick Actions */}
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-3 gap-2">
           <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
             <Button onClick={onReset} variant="outline" className="w-full bg-transparent" size="sm">
-              <RotateCcw className="h-4 w-4 mr-2" /> Reset
+              <RotateCcw className="h-4 w-4 mr-1" /> Reset
             </Button>
           </motion.div>
           <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
             <Button onClick={onExplode} variant="outline" className="w-full bg-transparent" size="sm">
-              <Zap className="h-4 w-4 mr-2" /> Explode
+              <Zap className="h-4 w-4 mr-1" /> Explode
+            </Button>
+          </motion.div>
+          <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            <Button onClick={onRandomize} variant="outline" className="w-full bg-transparent" size="sm">
+              <Dices className="h-4 w-4 mr-1" /> Random
             </Button>
           </motion.div>
         </div>


### PR DESCRIPTION
**Added a Randomize button** to the particle controls tab that sets all control sliders, toggles, and options to random values. This encourages experimentation and can produce unexpected and interesting visual effects.

**Changes:**

- Added a Randomize button with the desired svg next to the existing Reset and Explode buttons.
- Randomizes numerical sliders (e.g., particle gap, gravity, noise, mouse force, click strength, hue rotation).
- Randomizes select options (e.g., filter, particle shape).

**Linked Issue:**
Fixes: #1 

**Screenshots :** 

- Mobile View 
<img width="419" height="695" alt="image" src="https://github.com/user-attachments/assets/13fabec2-590d-41cb-8e7e-d1b87e5b17da" />

- Desktop View
<img width="1177" height="770" alt="image" src="https://github.com/user-attachments/assets/cb42ef4a-4167-4c1f-b301-d613a124d2cf" />

