### PR TITLE
Add Randomize Button 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "prettier": "^3.6.2",
         "tw-animate-css": "^1.3.5",
         "vite": "^7.0.4",
         "vite-react-ssg": "^0.8.8"
@@ -4990,6 +4991,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "prettier": "^3.6.2",
     "tw-animate-css": "^1.3.5",
     "vite": "^7.0.4",
     "vite-react-ssg": "^0.8.8"

--- a/src/components/ParticleApp.jsx
+++ b/src/components/ParticleApp.jsx
@@ -32,6 +32,47 @@ const ParticleApp = () => {
     vortexMode: false,
   });
 
+    const controlSections = [
+    {
+      title: "Physics",
+      icon: Settings,
+      controls: [
+        {
+          key: "particleGap",
+          label: "Particle Gap",
+          min: 2,
+          max: 10,
+          step: 1,
+          description: "Spacing between particles",
+        },
+        { key: "gravity", label: "Gravity", min: 0.01, max: 0.2, step: 0.01, description: "Return force strength" },
+        { key: "noise", label: "Noise", min: 0, max: 50, step: 1, description: "Random movement" },
+      ],
+    },
+    {
+      title: "Interaction",
+      icon: MousePointer,
+      controls: [
+        {
+          key: "mouseForce",
+          label: "Mouse Force",
+          min: 10,
+          max: 100,
+          step: 1,
+          description: "Mouse repulsion strength",
+        },
+        {
+          key: "clickStrength",
+          label: "Click Power",
+          min: 0,
+          max: 200,
+          step: 1,
+          description: "Click interaction force",
+        },
+      ],
+    },
+  ]
+
   // Default image URL
   const [imageUrl, setImageUrl] = useState("favicon_io/img.png");
 
@@ -60,6 +101,27 @@ const ParticleApp = () => {
   const handleExplode = useCallback(() => {
     setExplodeTrigger((prev) => prev + 1);
   }, []);
+
+
+const handleRandomize = () => {
+  const newConfig = { ...config };
+
+  controlSections.forEach(section => {
+    section.controls.forEach(ctrl => {
+      const rand =
+        ctrl.min +
+        Math.random() * (ctrl.max - ctrl.min);
+
+      const steps = Math.round((rand - ctrl.min) / ctrl.step);
+      newConfig[ctrl.key] = +(ctrl.min + steps * ctrl.step).toFixed(2); // 2 decimals
+    });
+  });
+
+  setConfig(newConfig);
+  setResetTrigger(prev => prev + 1);
+};
+
+
 
   const handleImageLoad = useCallback((newImageUrl) => {
     setImageUrl(newImageUrl);
@@ -243,6 +305,7 @@ const ParticleApp = () => {
                 onConfigChange={handleConfigChange}
                 onReset={handleReset}
                 onExplode={handleExplode}
+                onRandomize={handleRandomize}
                 onImageLoad={handleImageLoad}
                 onClose={() => setControlsOpen(false)}
               />
@@ -273,6 +336,7 @@ const ParticleApp = () => {
                         onConfigChange={handleConfigChange}
                         onReset={handleReset}
                         onExplode={handleExplode}
+                        onRandomize={handleRandomize}
                         onImageLoad={handleImageLoad}
                         onClose={() => setControlsOpen(false)}
                       />

--- a/src/components/ParticleCanvas.jsx
+++ b/src/components/ParticleCanvas.jsx
@@ -70,6 +70,7 @@ const ParticleCanvas = ({
     }
   }, [explodeTrigger]);
 
+
   useEffect(() => {
     if (particleCanvasRef.current) {
       particleCanvasRef.current.updateConfig({ imageSrc: imageUrl });

--- a/src/components/ParticleControl.jsx
+++ b/src/components/ParticleControl.jsx
@@ -87,23 +87,23 @@ const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onRandom
       <CardContent className="space-y-6 px-2">
         {/* Quick Actions */}
         <div className="flex gap-1">
-  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="flex-1">
+  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} >
     <Button onClick={onReset} variant="outline" className="w-full bg-transparent" size="sm">
       <RotateCcw className="h-4 w-4 mr-0" /> Reset
     </Button>
   </motion.div>
-  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="flex-1">
+  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} >
     <Button onClick={onExplode} variant="outline" className="w-full bg-transparent" size="sm">
       <Zap className="h-4 w-4 mr-0" /> Explode
     </Button>
   </motion.div>
-  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="flex-1">
+  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} >
     <Button onClick={onRandomize} variant="outline" className="w-full bg-transparent" size="sm">
       <Dices className="h-4 w-4 mr-0" /> Randomize
     </Button>
   </motion.div>
 </div>
-
+        
 
         <Tabs defaultValue="physics" className="w-full">
           <TabsList className="grid w-full grid-cols-3 h-auto p-1">

--- a/src/components/ParticleControl.jsx
+++ b/src/components/ParticleControl.jsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { motion } from "framer-motion"
-import { RotateCcw, Zap, Upload, Settings, Palette, MousePointer, Code, X, Dice6 } from "lucide-react"
+import { RotateCcw, Zap, Upload, Settings, Palette, MousePointer, Code, X, Dices } from "lucide-react"
 import CodeSnippet from "./CodeSnippet"
 
 const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onRandomize, onImageLoad, onClose }) => {
@@ -99,7 +99,7 @@ const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onRandom
           </motion.div>
           <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
             <Button onClick={onRandomize} variant="outline" className="w-full bg-transparent" size="sm">
-              <Dice6 className="h-4 w-4 mr-2" /> Randomize
+              <Dices className="h-4 w-4 mr-2" /> Randomize
             </Button>
           </motion.div>
         </div>

--- a/src/components/ParticleControl.jsx
+++ b/src/components/ParticleControl.jsx
@@ -9,10 +9,10 @@ import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { motion } from "framer-motion"
-import { RotateCcw, Zap, Upload, Settings, Palette, MousePointer, Code, X } from "lucide-react"
+import { RotateCcw, Zap, Upload, Settings, Palette, MousePointer, Code, X, Dice6 } from "lucide-react"
 import CodeSnippet from "./CodeSnippet"
 
-const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onImageLoad, onClose }) => {
+const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onRandomize, onImageLoad, onClose }) => {
   const handleSliderChange = (key, value) => {
     onConfigChange({ ...config, [key]: value[0] })
   }
@@ -95,6 +95,11 @@ const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onImageL
           <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
             <Button onClick={onExplode} variant="outline" className="w-full bg-transparent" size="sm">
               <Zap className="h-4 w-4 mr-2" /> Explode
+            </Button>
+          </motion.div>
+          <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            <Button onClick={onRandomize} variant="outline" className="w-full bg-transparent" size="sm">
+              <Dice6 className="h-4 w-4 mr-2" /> Randomize
             </Button>
           </motion.div>
         </div>

--- a/src/components/ParticleControl.jsx
+++ b/src/components/ParticleControl.jsx
@@ -84,25 +84,26 @@ const ParticleControls = ({ config, onConfigChange, onReset, onExplode, onRandom
         </div>
         <p className="text-sm text-muted-foreground">Customize your particle effects in real-time</p>
       </CardHeader>
-      <CardContent className="space-y-6">
+      <CardContent className="space-y-6 px-2">
         {/* Quick Actions */}
-        <div className="grid grid-cols-2 gap-3">
-          <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-            <Button onClick={onReset} variant="outline" className="w-full bg-transparent" size="sm">
-              <RotateCcw className="h-4 w-4 mr-2" /> Reset
-            </Button>
-          </motion.div>
-          <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-            <Button onClick={onExplode} variant="outline" className="w-full bg-transparent" size="sm">
-              <Zap className="h-4 w-4 mr-2" /> Explode
-            </Button>
-          </motion.div>
-          <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-            <Button onClick={onRandomize} variant="outline" className="w-full bg-transparent" size="sm">
-              <Dices className="h-4 w-4 mr-2" /> Randomize
-            </Button>
-          </motion.div>
-        </div>
+        <div className="flex gap-1">
+  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="flex-1">
+    <Button onClick={onReset} variant="outline" className="w-full bg-transparent" size="sm">
+      <RotateCcw className="h-4 w-4 mr-0" /> Reset
+    </Button>
+  </motion.div>
+  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="flex-1">
+    <Button onClick={onExplode} variant="outline" className="w-full bg-transparent" size="sm">
+      <Zap className="h-4 w-4 mr-0" /> Explode
+    </Button>
+  </motion.div>
+  <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="flex-1">
+    <Button onClick={onRandomize} variant="outline" className="w-full bg-transparent" size="sm">
+      <Dices className="h-4 w-4 mr-0" /> Randomize
+    </Button>
+  </motion.div>
+</div>
+
 
         <Tabs defaultValue="physics" className="w-full">
           <TabsList className="grid w-full grid-cols-3 h-auto p-1">


### PR DESCRIPTION
### Summary
This PR improves the Particle Controls panel by adding a **Randomize button** and fixing layout issues for mobile devices. 
It ensures a consistent, responsive, and intuitive user experience across both desktop and mobile platforms.

### Changes
1. **Randomize Button**
   - Added a functional **Randomize** button alongside existing **Reset** and **Explode** buttons.
   - Clicking it applies random values to particle settings in real-time.

### Screenshots / Recordings
- **Desktop version:**  
<img width="830" height="433" alt="image" src="https://github.com/user-attachments/assets/a9245fb2-84ca-41ef-8ed2-13a12459497e" />

https://github.com/user-attachments/assets/e3901d9b-e02b-4469-9c76-aa0783ea4888



- **Mobile version:**  
- ![mobile version](https://github.com/user-attachments/assets/1d4934ce-9ab0-4bd2-8128-ff0a808c9f96)

I believe the alignment of the physics line has changed cause screenshot was taken on ios device 


### Testing
- Verified that the Randomize button works correctly on both desktop and mobile.
- Checked headings alignment and wrapping on small screens.
- Confirmed existing buttons (Reset, Explode) maintain proper functionality.

### Notes
- Closes any issues related to adding the Randomize button and mobile layout fixes.
- Further UI improvements can be added in future PRs if needed.

Fixes: #1 #12 
